### PR TITLE
Add course outline and session log

### DIFF
--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,8 +6,9 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
-### Contents outline [Codex] 2025-07-06 <HH>:<MM>
+### Contents outline [Codex] 2025-07-06 15:20
 
+- Added course outline to landing page and updated session log
 
 ### Contents outline [Data Engineer] Codex prompt 2025-07-06 14:50
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,11 +1,32 @@
-# Prompt Engineering guide
-This guide provides information for Prompt Engineering and working with LLMs
+# Prompt Engineering Guide
+This guide provides information for Prompt Engineering and working with LLMs.
 
 ## Topics
-Topics covered in this guide
-
+The course focuses on:
 - Natural Language Processing (NLP)
 - AI application development
-- solutions driven by large language models (LLM)
-- Large Language Models: GPT-3/4, Claude, etc..
+- Solutions driven by large language models (LLM)
+- Large Language Models: GPT-3/4, Claude, etc.
 - Prompt Engineering concepts
+
+## Course Outline
+- **Introduction to NLP**
+  - fundamentals of text processing and tokenization
+  - embeddings and semantic understanding
+- **Large Language Models**
+  - overview of GPT-3/4, Claude and other providers
+  - transformer architecture basics
+  - using APIs for inference and evaluation
+- **Prompt Engineering Fundamentals**
+  - prompt design best practices
+  - zero-shot, few-shot and chain-of-thought techniques
+  - system versus user prompts
+- **AI Application Development**
+  - integrating LLM APIs into applications
+  - feedback loops and model evaluation
+  - safety and responsible use
+- **LLM Solutions**
+  - building chatbots and conversational agents
+  - summarization and question answering
+  - domain-specific automation examples
+


### PR DESCRIPTION
## Summary
- expand the landing page with a detailed course outline
- log session activity for Codex in the release document

## Testing
- `mkdocs build -s`

------
https://chatgpt.com/codex/tasks/task_e_686a1cff655483239d6d748c2eeb9e86