### PR TITLE
Expand weekly curriculum pages

### DIFF
--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,7 +6,9 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
-### Contents development [Codex] 2025-07-06 <HH>:<MM>
+### Contents development [Codex] 2025-07-06 15:29
+- Expanded each weekly module to multi-page lecture notes
+- Added course schedule on landing page
 
 ### Contents development [Data Engineer] Codex prompt 2025-07-06 15:20
 

--- a/docs/01_natural_language_processing.md
+++ b/docs/01_natural_language_processing.md
@@ -1,17 +1,77 @@
 # Natural Language Processing
 
-This week introduces fundamental techniques for working with human language data. We explore how raw text is prepared, represented and embedded for downstream tasks.
+Natural Language Processing (NLP) is the discipline focused on understanding and generating human language with computers. In our first week we build the foundational toolkit for working with raw text. The goal is to transform unstructured sentences into representations that can be fed into language models or traditional machine learning pipelines.
 
-## Text Preprocessing
-- Normalization and cleaning of text
-- Tokenization strategies: word, subword and byte pair encoding
-- Handling stop words and punctuation
+## 1. Overview of NLP Tasks
+NLP spans a broad range of tasks from tokenization and part-of-speech tagging to machine translation and text generation. We examine the classic pipeline of text classification, named entity recognition and summarization. Each task benefits from accurate preprocessing and token management, topics that we will explore in depth.
 
-## Word Representations
-Classical methods such as bag-of-words and TF‑IDF are covered before moving to neural embeddings like word2vec and GloVe. These representations capture semantic relationships between terms.
+### Example
+A typical text classification workflow reads a document, splits it into tokens, removes non-essential words and converts the remaining terms into numerical features. These features are then fed into a classifier, such as logistic regression or a neural network, to predict sentiment or other labels.
 
-## Embeddings and Semantic Search
-Modern models produce vector embeddings that allow similarity search and clustering. We discuss cosine similarity, vector space properties and how embeddings power search applications.
+## 2. Text Preprocessing
+Before we can use text in downstream models, we clean and normalize it. Typical steps include lowercasing, removing punctuation and expanding contractions. Tokenization divides the text into units—either words or subwords—so that the model can assign numerical values.
+- **Normalization**: Convert text to lowercase and standardize punctuation or white space.
+- **Tokenization**: Using rules-based or statistical approaches, break text into words or subwords. Libraries such as spaCy or NLTK provide tokenizers for many languages.
+- **Stop Word Removal**: Many analyses remove common words ("the", "and") to focus on informative terms.
+- **Stemming and Lemmatization**: Reduce words to their root forms. Stemming uses heuristics to chop off endings, while lemmatization references dictionaries for correct morphological forms.
 
-## Practical Exercise
-Using Python libraries (NLTK, spaCy), process a small corpus, create embeddings and perform a similarity query.
+### Code Example
+```python
+import spacy
+nlp = spacy.load('en_core_web_sm')
+doc = nlp("Cats running and dogs run")
+print([token.lemma_ for token in doc])
+```
+
+## 3. Classical Representations
+Early NLP models relied on bag-of-words features. Each document is represented by a vector that counts the occurrences of every term. TF‑IDF weighting scales the counts to emphasize distinctive words and downplay common terms. Despite their simplicity, these representations still perform well in some tasks.
+
+### N-grams
+To capture short phrases, we can use n-gram features. A bigram model represents consecutive word pairs; a trigram model uses three-word sequences. These features help with tasks like language detection and topic modeling.
+
+## 4. Distributed Embeddings
+Neural embeddings offer dense representations that encode semantic similarity between words. Word2vec and GloVe learn vectors by predicting contexts or factorizing co-occurrence matrices. Similar words appear close together in vector space.
+
+### Contextual Embeddings
+Recent models such as ELMo and BERT produce token embeddings that depend on the sentence. A word like "bank" yields different vectors in "river bank" versus "bank account." These embeddings are the starting point for modern large language models.
+
+### Training Word2vec
+```python
+from gensim.models import Word2Vec
+sentences = [['this','is','a','sentence'], ['this','is','another']]
+model = Word2Vec(sentences, vector_size=100, window=5, min_count=1)
+vector = model.wv['sentence']
+```
+
+## 5. Embedding Spaces and Similarity
+Once words or sentences are embedded into vectors, we can measure similarity with distances such as cosine or Euclidean metrics. Nearby vectors indicate semantic closeness. This property underpins search, clustering and recommendation systems.
+
+### Vector Arithmetic
+Word embeddings support analogies like `king - man + woman ≈ queen`. By subtracting and adding vectors we capture relationships between concepts.
+
+## 6. Semantic Search and Clustering
+To build a semantic search engine, we embed user queries and corpus documents into the same vector space. A similarity search (often using approximate nearest neighbors) retrieves documents with vectors nearest to the query vector. Clustering algorithms like K-means can reveal topical structure in the corpus.
+
+## 7. Evaluation Metrics
+Common metrics for evaluating NLP pipelines include precision, recall and F1 score for classification, or BLEU and ROUGE for machine translation and summarization. Proper evaluation helps compare algorithms and tune hyperparameters.
+
+## 8. Practical Exercise
+The assignment for this module is to implement a small semantic search engine. Using Python libraries such as spaCy and scikit-learn, you will:
+1. Preprocess a text dataset by tokenizing, lemmatizing and removing stop words.
+2. Generate TF‑IDF features and train a basic classifier.
+3. Create sentence embeddings using a transformer model like `all-MiniLM` from the `sentence-transformers` package.
+4. Perform a similarity query and evaluate the retrieval quality.
+
+### Sample Setup Code
+```python
+from sentence_transformers import SentenceTransformer, util
+model = SentenceTransformer('all-MiniLM-L6-v2')
+corpus = ["NLP is fun", "We study language", "Transformers are powerful"]
+corpus_embeddings = model.encode(corpus, convert_to_tensor=True)
+query = "language models"
+query_embedding = model.encode(query, convert_to_tensor=True)
+results = util.semantic_search(query_embedding, corpus_embeddings, top_k=2)
+print(results)
+```
+
+By the end of week one, you should be comfortable preparing text for advanced models, generating embeddings and measuring similarity. These skills are essential for all subsequent weeks of the course.

--- a/docs/02_large_language_models.md
+++ b/docs/02_large_language_models.md
@@ -1,16 +1,52 @@
 # Large Language Models
 
-Week two explores the architecture and usage of modern large language models.
+Modern large language models (LLMs) such as GPT-4, Claude and open-source alternatives are built upon the transformer architecture. This week provides a deep dive into how these models are trained and how we can use them effectively.
 
-## Model Families
-- GPT-3/4 and Claude
-- open source alternatives
+## 1. Model Families
+LLM providers fall into two broad categories: proprietary offerings like OpenAI’s GPT series or Anthropic’s Claude, and open models such as Llama or Mistral. Each family offers different licensing terms and API interfaces, but the underlying neural architecture shares common principles.
 
-## Transformer Architecture
-An overview of attention mechanisms, positional encoding and the training objective behind autoregressive models.
+### Proprietary Models
+- **GPT-3/4**: Developed by OpenAI, these models are known for their extensive training data and high-quality generation.
+- **Claude**: Anthropic’s assistant focuses on safety and steerable responses.
 
-## Using Hosted APIs
-Practical tips for sending prompts, handling rate limits and interpreting model outputs. Examples show the differences between providers.
+### Open Source Alternatives
+- **Llama** from Meta and **Mistral** from independent labs show that smaller, efficient models can achieve competitive performance when fine-tuned on domain-specific data. Running open models locally gives greater control over data privacy and cost.
 
-## Ethical and Practical Concerns
-Discuss data privacy, bias and the environmental impact of training large models.
+## 2. Transformer Architecture
+The transformer revolutionized NLP by introducing self-attention mechanisms. Each layer computes queries, keys and values to weigh the importance of surrounding tokens. Positional encodings supply order information, while residual connections and layer normalization aid optimization.
+
+### Autoregressive Training
+LLMs are typically trained to predict the next token in a sequence. This objective encourages the model to learn grammar, semantics and even factual knowledge from the training corpus.
+
+### Scaling Laws
+Research shows that model performance scales predictably with data, parameter count and compute budget. Understanding these relationships helps when deciding between a smaller local model and a large hosted service.
+
+## 3. Using Hosted APIs
+Most developers access LLMs through web APIs. When sending prompts, it’s important to manage context length, system instructions and rate limits. Providers like OpenAI return responses in JSON format with metadata. Error handling ensures robust applications.
+
+### Example
+```python
+import openai
+openai.api_key = "YOUR_KEY"
+response = openai.ChatCompletion.create(
+    model="gpt-4",
+    messages=[{"role": "user", "content": "Explain transformers"}]
+)
+print(response.choices[0].message.content)
+```
+
+### Tips
+- Cache frequent prompts to reduce latency and cost.
+- Monitor token usage to avoid unexpected bills.
+- Evaluate model outputs for bias or inappropriate content.
+
+## 4. Evaluation and Fine-tuning
+While base models provide impressive capabilities, performance often improves with fine-tuning on task-specific data. Evaluation metrics such as perplexity, BLEU or human preference scores help determine whether fine-tuning is necessary.
+
+### Parameter-Efficient Methods
+Techniques like LoRA (Low-Rank Adaptation) and prompt tuning modify only a small subset of model parameters or the input embeddings, enabling efficient adaptation even on modest hardware.
+
+## 5. Ethical and Practical Concerns
+Large models inherit biases present in their training data. It is critical to monitor for unfair or harmful outputs. Data privacy must be considered when sending user content to hosted services. Finally, the energy consumption required to train these models raises environmental concerns. Organizations should weigh these factors when deciding on adoption.
+
+By the end of week two you will be able to describe the architecture of modern LLMs, interact with them via APIs and understand the trade-offs between proprietary and open-source solutions.

--- a/docs/03_rag_embedding.md
+++ b/docs/03_rag_embedding.md
@@ -1,16 +1,53 @@
 # RAG, Embedding and Vector Databases
 
-Retrieval Augmented Generation (RAG) integrates external knowledge retrieval with language model generation. Week three dives into this architecture.
+Retrieval Augmented Generation (RAG) combines the reasoning abilities of language models with the accuracy of external knowledge bases. In week three we learn to build systems that fetch relevant context and feed it to a generator model.
 
-## The RAG Workflow
-- Query encoding and retrieval from knowledge sources
-- Feeding retrieved contexts into a generator model
+## 1. The RAG Workflow
+1. **Query Encoding**: The user question or prompt is embedded using a transformer encoder.
+2. **Vector Retrieval**: The embedding is compared to vectors stored in a database. The most similar passages are retrieved.
+3. **Generation**: The retrieved text chunks are provided to a language model which produces a final answer grounded in that context.
 
-## Embedding Models
-We survey sentence transformers and other models that convert text into dense vectors suitable for similarity search.
+By retrieving supporting evidence, RAG reduces hallucination and enables up-to-date information without retraining the model.
 
-## Vector Databases
-Vector stores such as FAISS, Qdrant and Weaviate support fast similarity search at scale. Concepts of indexing, sharding and metadata filtering are discussed.
+## 2. Embedding Models
+Sentence transformers (e.g., `all-MiniLM` or `bge-large`) convert text into high-dimensional vectors. These vectors capture semantic meaning, allowing similarity search. Fine-tuning on domain data improves retrieval quality.
 
-## Implementation Exercise
-Build a simple RAG pipeline that embeds documents, stores them in a vector database and answers questions by retrieving relevant chunks.
+### Training Strategies
+- **Unsupervised**: Use contrastive learning on large corpora to build general-purpose embeddings.
+- **Supervised**: Train on question–answer pairs or labelled data for more accurate retrieval.
+
+## 3. Vector Databases
+Specialized databases store millions of embeddings and provide efficient similarity search. Popular options include:
+- **FAISS**: A library for indexing and searching high-dimensional vectors. It offers product quantization and GPU acceleration.
+- **Qdrant** and **Weaviate**: Standalone services that store vectors with associated metadata. They support filtering, sharding and persistence.
+
+### Indexing
+Vectors are often compressed or quantized for speed. Inverted file (IVF) indexes and HNSW graphs allow approximate nearest-neighbor search with controllable accuracy.
+
+## 4. Building a RAG System
+1. Chunk documents into passages (e.g., 200–300 words).
+2. Embed each chunk and store it in a vector database along with metadata.
+3. When a query arrives, encode it and retrieve the top-k similar chunks.
+4. Assemble a prompt that includes the retrieved context and ask the language model to answer based only on that information.
+
+### Example Code Snippet
+```python
+from langchain.embeddings import HuggingFaceEmbeddings
+from langchain.vectorstores import FAISS
+
+embed = HuggingFaceEmbeddings(model_name='all-MiniLM-L6-v2')
+texts = ["Document chunk one", "Another chunk"]
+store = FAISS.from_texts(texts, embed)
+question = "What is in the document?"
+matched_docs = store.similarity_search(question)
+```
+
+## 5. Challenges and Best Practices
+- **Chunking Strategy**: Overlapping windows can preserve context but increase storage.
+- **Metadata**: Storing source links allows the generation step to cite references.
+- **Freshness**: Periodically re-embed new documents so the knowledge base stays current.
+
+## 6. Implementation Exercise
+Create a simple question-answering system that reads a set of articles, embeds them into a FAISS index and uses an LLM to respond to user questions with retrieved passages. Evaluate how retrieval quality changes when using different embedding models or index parameters.
+
+By completing week three you will know how to integrate vector search with language models to build applications that provide grounded, accurate answers.

--- a/docs/04_prompt_engineering.md
+++ b/docs/04_prompt_engineering.md
@@ -1,16 +1,44 @@
 # Prompt Engineering
 
-Week four focuses on crafting prompts that produce reliable and reproducible outputs from language models.
+Week four explores how to craft prompts that reliably steer language models toward the desired output. Well-designed prompts can dramatically improve accuracy and reduce unwanted behavior.
 
-## Prompt Design Principles
-- Clarity and context
-- Choosing the right persona or system message
-- Controlling temperature and response length
+## 1. Prompt Design Principles
+A prompt should clearly state the task and provide any needed context. Typically we include a system or persona message to guide style and tone. Explicit instructions about output format help prevent confusion.
 
-## Advanced Techniques
-- Zero-shot and few-shot prompting
-- Chain-of-thought reasoning and self-consistency
-- Using delimiters and explicit formatting instructions
+### Guidelines
+- Keep instructions concise yet specific.
+- Use delimiters such as triple backticks to separate instructions from user content.
+- Include examples of correct output when possible.
+- Control randomness with the temperature and top‑p parameters.
 
-## Example Templates
-Provide sample prompts for summarization, extraction and conversational agents.
+## 2. Zero-shot, Few-shot and Chain-of-Thought
+- **Zero-shot**: Ask the model to perform the task directly with no examples.
+- **Few-shot**: Provide a handful of labeled examples within the prompt to establish the pattern.
+- **Chain-of-thought**: Encourage multi-step reasoning by telling the model to explain its steps before giving the final answer.
+
+### Self-consistency
+By generating several chain-of-thought responses and voting on the most consistent outcome, we can achieve higher accuracy on complex reasoning tasks.
+
+## 3. Using System Prompts
+System prompts establish the role or persona of the assistant, such as "You are a helpful travel planner." Distinguishing between system and user prompts prevents instructions from being interpreted as user input.
+
+### Controlling Style
+We can mimic styles ranging from academic explanations to casual conversation. Including explicit style cues helps tailor the voice to the target audience.
+
+## 4. Advanced Formatting
+When output needs to be machine-readable, we can instruct the model to respond in JSON or Markdown. Using placeholders and bullet lists reduces variation in the output structure.
+
+### Example Prompt
+```
+You are a concise consultant.
+Answer the question using three bullet points.
+Question: How can I reduce latency in a web app?
+```
+
+## 5. Prompt Iteration and Evaluation
+Developing a good prompt is an iterative process. Start with a clear baseline, test the output on multiple examples and refine. Automated evaluation frameworks such as OpenAI’s prompt engineering tools or the `langchain` evaluator can assist with this process.
+
+## 6. Practical Exercise
+Design prompts for a summarization tool and a data extraction pipeline. Experiment with different temperature settings and evaluate how formatting instructions affect the consistency of the model’s responses.
+
+By the end of week four you will be able to write prompts that consistently guide LLMs to produce high-quality, safe and formatted output for a variety of tasks.

--- a/docs/05_ai_applications.md
+++ b/docs/05_ai_applications.md
@@ -1,14 +1,29 @@
 # AI Applications
 
-Week five demonstrates how to integrate LLMs into end-to-end applications.
+Week five focuses on integrating language models into real-world applications. We explore common patterns and discuss how to evaluate systems in production.
 
-## Application Patterns
-- Chatbots and conversational agents
-- Document summarization services
-- Knowledge extraction pipelines
+## 1. Application Patterns
+LLMs power a variety of services including chatbots, summarization tools and knowledge extraction pipelines. We survey each of these patterns and discuss the design considerations involved.
 
-## Evaluation and Feedback
-Techniques for monitoring quality, collecting user feedback and performing A/B tests on prompts.
+### Chatbots and Assistants
+Conversational agents require state management to maintain context across turns. Techniques such as conversation memory or storing user history in a database help create natural, continuous interactions.
 
-## Safety Considerations
-Address risks such as hallucination, privacy leakage and misuse. Introduce policy enforcement and red teaming.
+### Summarization Services
+Automatic summarization condenses large documents into key points. Whether abstractive or extractive, summarizers rely on well-crafted prompts and often incorporate feedback from human reviewers.
+
+### Knowledge Extraction
+Businesses use LLMs to identify entities and relationships within text. By combining extraction prompts with downstream databases, we can build structured knowledge bases from unstructured sources.
+
+## 2. Evaluation and Feedback
+Deploying an LLM-powered app is an iterative process. We should monitor metrics such as response quality, latency and user satisfaction. A/B testing different prompt templates or model parameters helps determine what works best. Collecting explicit user feedback allows continuous improvement.
+
+### Human-in-the-Loop
+In sensitive domains, humans review model outputs before final delivery. This ensures accuracy and prevents harmful content from reaching end users.
+
+## 3. Safety Considerations
+LLMs can hallucinate or produce biased text. Implement guardrails such as content filters, rate limiting and logging. Privacy is also vital—avoid sending sensitive user data to external services unless it has been properly anonymized and consent has been obtained.
+
+## 4. Implementation Exercise
+Design a simple application that integrates a chat interface with an LLM API. Track metrics such as user retention and feedback ratings. Experiment with prompt variants to improve helpfulness while maintaining safe responses.
+
+After week five you will know how to plan and build LLM applications with a focus on evaluation, safety and user-centered design.

--- a/docs/06_ai_agent_langchain.md
+++ b/docs/06_ai_agent_langchain.md
@@ -1,16 +1,34 @@
 # AI Agent Development using LangChain
 
-Week six introduces LangChain, a framework for composing LLM powered agents.
+In week six we explore LangChain, a Python framework for building agents that chain multiple language model calls and tools together.
 
-## Building Chains
-- Linking prompts and tools to create task-specific workflows
-- Managing memory and conversation state
+## 1. Building Chains
+A chain is a sequence of prompts, model invocations and actions. LangChain makes it easy to connect these steps so that the output of one becomes the input of the next.
 
-## Tools and Plugins
-Overview of available integrations for search, code execution and external APIs.
+### Memory Management
+Conversation memory objects store user messages and model responses. This allows an agent to maintain context over extended dialogues. Different memory types support summarization or token-limited histories.
 
-## Multi-step Agents
-Combine retrieval, reasoning and action in a single agent. Discuss best practices for debugging and tracing chains.
+## 2. Tools and Plugins
+LangChain integrates with many tools such as web search, code execution sandboxes and vector stores. Tools are invoked by the agent when it determines additional data is needed to answer a question.
 
-## Example Project
-Implement a simple question answering assistant that uses a vector store and custom tools.
+### Custom Tools
+Developers can define their own tools by writing a function and registering it with the agent. Tools may access internal APIs, databases or external services.
+
+## 3. Multi-step Agents
+Complex tasks often require retrieval, reasoning and action in sequence. For example an agent might search documentation, parse the results and then compose a concise answer. LangChain provides higher-level agent classes that handle decision making and tool selection.
+
+### Debugging and Tracing
+LangChain includes verbose logging and tracing utilities. These help inspect the reasoning process of the agent and diagnose unexpected behavior.
+
+## 4. Example Project
+Build a question answering assistant that looks up information in a vector store before replying. The chain uses the following steps:
+1. Receive the user question.
+2. Retrieve relevant documents from a vector database.
+3. Feed the documents and question to a language model.
+4. Return the model’s summarized answer along with references.
+
+## 5. Further Exploration
+- Experiment with different chain structures such as sequential chains or parallel tool calls.
+- Use the LangChain evaluation module to benchmark your agent’s performance.
+
+By the end of week six you will be prepared to design complex LLM agents that use external tools and memory to solve real problems.

--- a/docs/07_llm_solutions.md
+++ b/docs/07_llm_solutions.md
@@ -1,12 +1,18 @@
 # LLM Solutions
 
-The final week surveys complete solutions built with language models across industries.
+The final week surveys complete solutions built with language models across different industries. We discuss deployment considerations and real-world success stories.
 
-## Conversational Systems
-Designing chatbots, virtual assistants and support tools with personas and memory.
+## 1. Conversational Systems
+Chatbots and virtual assistants automate customer service and technical support. Effective systems combine retrieval (for factual accuracy) with dialogue management. Tools such as sentiment detection help tailor responses to user emotions.
 
-## Summarization and QA
-Implementing summarizers, question answerers and report generation pipelines.
+## 2. Summarization and Question Answering
+Organizations use LLMs to condense lengthy reports or answer natural language queries over internal documents. Combining RAG pipelines with prompt engineering yields concise, trustworthy results.
 
-## Domain Automation
-Examples from finance, healthcare and education where LLMs automate specialized tasks.
+## 3. Domain Automation
+In finance, language models analyze market reports and generate portfolio summaries. Healthcare applications include patient triage chatbots and medical coding assistance. In education, tutors generate practice questions and personalized feedback.
+
+## 4. Deployment Considerations
+To run these solutions at scale we need secure infrastructure, monitoring and failover plans. Choosing between cloud-hosted APIs or self-hosted models depends on latency, cost and privacy requirements. Logging and analytics help track performance over time.
+
+## 5. Capstone Project
+Students are encouraged to design a small end-to-end application incorporating retrieval, prompt engineering and an LLM agent. Presentations at the end of the course showcase the creativity and technical depth achieved during the seven weeks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,3 +37,12 @@ The course focuses on:
   - summarization and question answering
   - domain-specific automation examples
 
+
+## Course Schedule
+Week 1: Natural Language Processing
+Week 2: Large Language Models
+Week 3: Retrieval Augmented Generation and Embedding
+Week 4: Prompt Engineering
+Week 5: AI Applications
+Week 6: AI Agent Development using LangChain
+Week 7: LLM Solutions and Project Showcase


### PR DESCRIPTION
## Summary
- flesh out NLP, LLM, RAG, prompt engineering, applications, LangChain and solutions pages
- add course schedule section to landing page
- log latest content development session

## Testing
- `pip install -r requirements.txt`
- `mkdocs build -q`


------
https://chatgpt.com/codex/tasks/task_e_686a24a109b083239319b4c2a09d4595