### PR TITLE
Add outlines and expand NLP content

### DIFF
--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,7 +6,12 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
-### NLP [Codex] 2025-07-06 <HH>:<MM>
+### NLP [Codex] 2025-07-06 15:47
+
+- Added contents outline sections to all topic pages
+- Expanded the Natural Language Processing page with fundamental theory and
+  machine learning sections
+- Updated the landing page to mention outlines for each topic
 
 
 ### NLP [Data Engineer] Codex prompt 2025-07-06 15:45

--- a/docs/01_natural_language_processing.md
+++ b/docs/01_natural_language_processing.md
@@ -4,15 +4,48 @@ Natural Language Processing (NLP) is the discipline focused on understanding and
 
 ## Outline
 
-_add the outline here_
+The key topics for this module are:
 
-## 1. Overview of NLP Tasks
+- fundamental theory and language structure
+- developing and training NLP models
+- overview of typical NLP tasks
+- text preprocessing techniques
+- classical representations such as bag-of-words
+- distributed embeddings and contextual vectors
+- embedding spaces and similarity search
+- clustering and semantic retrieval
+- evaluation metrics for NLP pipelines
+- machine learning with NLP features
+- a hands-on practical exercise
+
+## 1. Fundamental Theory and Concepts of NLP
+
+NLP builds upon linguistics, the scientific study of language. At the **word**
+level we analyze morphology: how words are formed from roots and affixes. The
+**grammar** or **syntactic** level concerns how words combine into valid
+sentences. Finally the **semantic** level addresses meaning and pragmatic
+interpretation. Understanding these structures is crucial for building models
+that do more than pattern matching. Many NLP tasks—from part-of-speech tagging
+to parsing—explicitly model these layers.
+
+## 2. Developing and Training NLP Models
+
+Modern NLP pipelines rely on large text corpora. A corpus is collected and
+cleaned before it is split into training, validation and test sets. Models are
+trained to predict tokens, tags or embeddings using algorithms such as
+conditional random fields or neural networks. During training we iterate over
+the corpus, computing gradients and updating parameters until the model
+generalizes well. Public corpora like Wikipedia or Common Crawl provide billions
+of tokens, but domain-specific collections are equally important for applied
+projects.
+
+## 3. Overview of NLP Tasks
 NLP spans a broad range of tasks from tokenization and part-of-speech tagging to machine translation and text generation. We examine the classic pipeline of text classification, named entity recognition and summarization. Each task benefits from accurate preprocessing and token management, topics that we will explore in depth.
 
 ### Example
 A typical text classification workflow reads a document, splits it into tokens, removes non-essential words and converts the remaining terms into numerical features. These features are then fed into a classifier, such as logistic regression or a neural network, to predict sentiment or other labels.
 
-## 2. Text Preprocessing
+## 4. Text Preprocessing
 Before we can use text in downstream models, we clean and normalize it. Typical steps include lowercasing, removing punctuation and expanding contractions. Tokenization divides the text into units—either words or subwords—so that the model can assign numerical values.
 - **Normalization**: Convert text to lowercase and standardize punctuation or white space.
 - **Tokenization**: Using rules-based or statistical approaches, break text into words or subwords. Libraries such as spaCy or NLTK provide tokenizers for many languages.
@@ -27,13 +60,13 @@ doc = nlp("Cats running and dogs run")
 print([token.lemma_ for token in doc])
 ```
 
-## 3. Classical Representations
+## 5. Classical Representations
 Early NLP models relied on bag-of-words features. Each document is represented by a vector that counts the occurrences of every term. TF‑IDF weighting scales the counts to emphasize distinctive words and downplay common terms. Despite their simplicity, these representations still perform well in some tasks.
 
 ### N-grams
 To capture short phrases, we can use n-gram features. A bigram model represents consecutive word pairs; a trigram model uses three-word sequences. These features help with tasks like language detection and topic modeling.
 
-## 4. Distributed Embeddings
+## 6. Distributed Embeddings
 Neural embeddings offer dense representations that encode semantic similarity between words. Word2vec and GloVe learn vectors by predicting contexts or factorizing co-occurrence matrices. Similar words appear close together in vector space.
 
 ### Contextual Embeddings
@@ -47,23 +80,58 @@ model = Word2Vec(sentences, vector_size=100, window=5, min_count=1)
 vector = model.wv['sentence']
 ```
 
-## 5. Embedding Spaces and Similarity
+## 7. Embedding Spaces and Similarity
 Once words or sentences are embedded into vectors, we can measure similarity with distances such as cosine or Euclidean metrics. Nearby vectors indicate semantic closeness. This property underpins search, clustering and recommendation systems.
 
 ### Vector Arithmetic
 Word embeddings support analogies like `king - man + woman ≈ queen`. By subtracting and adding vectors we capture relationships between concepts.
 
-## 6. Semantic Search and Clustering
+## 8. Semantic Search and Clustering
 To build a semantic search engine, we embed user queries and corpus documents into the same vector space. A similarity search (often using approximate nearest neighbors) retrieves documents with vectors nearest to the query vector. Clustering algorithms like K-means can reveal topical structure in the corpus.
 
-## 7. Evaluation Metrics
+## 9. Evaluation Metrics
 Common metrics for evaluating NLP pipelines include precision, recall and F1 score for classification, or BLEU and ROUGE for machine translation and summarization. Proper evaluation helps compare algorithms and tune hyperparameters.
 
-## XX. Machine learning with NLP
+## 10. Machine Learning with NLP
 
-_elaborate a few sections with examples for using NLP as part of building an ML model for classification, regression and unsupervised learning tasks
+Machine learning techniques turn processed text into actionable predictions.
+Below we examine how unstructured data is transformed into features and how
+those features drive various algorithms.
 
-## XX. Practical Exercise
+### Using Unstructured Text
+Raw documents must be tokenized and vectorized before they can feed an ML
+pipeline. Common approaches include bag-of-words counts, TF‑IDF weights and
+pretrained embeddings. These representations transform arbitrary length text
+into fixed-length numeric vectors suitable for scikit-learn or deep learning
+frameworks.
+
+### Tokens as Features
+Tokens or n‑grams can be treated as categorical variables. With large vocabularies
+we typically apply hashing or dimensionality reduction to keep feature spaces
+manageable. Embeddings offer dense alternatives that capture semantic meaning
+beyond surface forms.
+
+### Classification and Regression
+Text classification predicts discrete labels such as sentiment or topic. In a
+regression setup the target might be a review score or popularity metric.
+Logistic regression, support vector machines and gradient boosting all work well
+with TF‑IDF or embedding features. Neural architectures like CNNs or transformers
+handle longer sequences directly and can be fine-tuned on domain corpora.
+
+### Unsupervised and Semi-supervised Methods
+Clustering groups documents by similarity without requiring labels. Topic models
+such as LDA reveal latent structure, while autoencoders learn compressed
+representations. Semi-supervised techniques leverage small labeled datasets with
+large amounts of unlabeled text to improve performance.
+
+### Other Applications
+Sequence tagging tasks like part-of-speech or entity recognition combine
+contextual embeddings with conditional random fields or recurrent networks.
+Generative models perform machine translation or summarization. All of these
+approaches rely on the same principle—encoding language into numerical features
+and optimizing a learning objective.
+
+## 11. Practical Exercise
 The assignment for this module is to implement a small semantic search engine. Using Python libraries such as spaCy and scikit-learn, you will:
 1. Preprocess a text dataset by tokenizing, lemmatizing and removing stop words.
 2. Generate TF‑IDF features and train a basic classifier.

--- a/docs/02_large_language_models.md
+++ b/docs/02_large_language_models.md
@@ -2,6 +2,14 @@
 
 Modern large language models (LLMs) such as GPT-4, Claude and open-source alternatives are built upon the transformer architecture. This week provides a deep dive into how these models are trained and how we can use them effectively.
 
+## Outline
+
+- model families and providers
+- transformer architecture basics
+- using hosted APIs
+- evaluation and fine-tuning
+- ethical and practical concerns
+
 ## 1. Model Families
 LLM providers fall into two broad categories: proprietary offerings like OpenAI’s GPT series or Anthropic’s Claude, and open models such as Llama or Mistral. Each family offers different licensing terms and API interfaces, but the underlying neural architecture shares common principles.
 

--- a/docs/03_rag_embedding.md
+++ b/docs/03_rag_embedding.md
@@ -2,6 +2,15 @@
 
 Retrieval Augmented Generation (RAG) combines the reasoning abilities of language models with the accuracy of external knowledge bases. In week three we learn to build systems that fetch relevant context and feed it to a generator model.
 
+## Outline
+
+- the RAG workflow
+- embedding models
+- vector databases
+- building a RAG system
+- challenges and best practices
+- implementation exercise
+
 ## 1. The RAG Workflow
 1. **Query Encoding**: The user question or prompt is embedded using a transformer encoder.
 2. **Vector Retrieval**: The embedding is compared to vectors stored in a database. The most similar passages are retrieved.

--- a/docs/04_prompt_engineering.md
+++ b/docs/04_prompt_engineering.md
@@ -2,6 +2,15 @@
 
 Week four explores how to craft prompts that reliably steer language models toward the desired output. Well-designed prompts can dramatically improve accuracy and reduce unwanted behavior.
 
+## Outline
+
+- prompt design principles
+- zero-shot, few-shot and chain-of-thought
+- using system prompts
+- advanced formatting
+- prompt iteration and evaluation
+- practical exercise
+
 ## 1. Prompt Design Principles
 A prompt should clearly state the task and provide any needed context. Typically we include a system or persona message to guide style and tone. Explicit instructions about output format help prevent confusion.
 

--- a/docs/05_ai_applications.md
+++ b/docs/05_ai_applications.md
@@ -2,6 +2,13 @@
 
 Week five focuses on integrating language models into real-world applications. We explore common patterns and discuss how to evaluate systems in production.
 
+## Outline
+
+- application patterns
+- evaluation and feedback
+- safety considerations
+- implementation exercise
+
 ## 1. Application Patterns
 LLMs power a variety of services including chatbots, summarization tools and knowledge extraction pipelines. We survey each of these patterns and discuss the design considerations involved.
 

--- a/docs/06_ai_agent_langchain.md
+++ b/docs/06_ai_agent_langchain.md
@@ -2,6 +2,14 @@
 
 In week six we explore LangChain, a Python framework for building agents that chain multiple language model calls and tools together.
 
+## Outline
+
+- building chains
+- tools and plugins
+- multi-step agents
+- example project
+- further exploration
+
 ## 1. Building Chains
 A chain is a sequence of prompts, model invocations and actions. LangChain makes it easy to connect these steps so that the output of one becomes the input of the next.
 

--- a/docs/07_llm_solutions.md
+++ b/docs/07_llm_solutions.md
@@ -2,6 +2,14 @@
 
 The final week surveys complete solutions built with language models across different industries. We discuss deployment considerations and real-world success stories.
 
+## Outline
+
+- conversational systems
+- summarization and question answering
+- domain automation
+- deployment considerations
+- capstone project
+
 ## 1. Conversational Systems
 Chatbots and virtual assistants automate customer service and technical support. Effective systems combine retrieval (for factual accuracy) with dialogue management. Tools such as sentiment detection help tailor responses to user emotions.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,9 @@
 # Prompt Engineering Guide
 This guide provides information for Prompt Engineering and working with LLMs.
 
+Each topic page includes a **Contents Outline** section at the beginning so you
+can quickly navigate the material and locate key subtopics.
+
 ## Topics
 The course focuses on:
 


### PR DESCRIPTION
## Summary
- add a note on the landing page explaining contents outlines
- insert contents outline sections on all topic pages
- expand NLP page with theory, training, and ML application sections
- update session log with latest activity

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a2965b128832389594e924234e524