### PR TITLE
Expand content across topic pages

### DIFF
--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,7 +6,14 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
-### Contents development [Codex] 2025-07-06 <HH>:<MM>
+### Contents development [Codex] 2025-07-06 16:02
+
+- Expanded all topic pages with detailed theory, data structures and algorithms
+  following the NLP chapter as a template
+- Added practical code examples across LLM, RAG, prompt engineering, agent and
+  application sections
+- Updated the landing page introduction
+- Logged progress in this session
 
 ### Contents development [Data Engineer] Codex prompt 2025-07-06 15:55
 

--- a/docs/02_large_language_models.md
+++ b/docs/02_large_language_models.md
@@ -6,9 +6,12 @@ Modern large language models (LLMs) such as GPT-4, Claude and open-source altern
 
 - model families and providers
 - transformer architecture basics
+- tokenization and vocabulary
+- training algorithms
 - using hosted APIs
 - evaluation and fine-tuning
 - ethical and practical concerns
+- hands-on code example
 
 ## 1. Model Families
 LLM providers fall into two broad categories: proprietary offerings like OpenAI’s GPT series or Anthropic’s Claude, and open models such as Llama or Mistral. Each family offers different licensing terms and API interfaces, but the underlying neural architecture shares common principles.
@@ -29,7 +32,13 @@ LLMs are typically trained to predict the next token in a sequence. This objecti
 ### Scaling Laws
 Research shows that model performance scales predictably with data, parameter count and compute budget. Understanding these relationships helps when deciding between a smaller local model and a large hosted service.
 
-## 3. Using Hosted APIs
+## 3. Tokenization and Vocabulary
+Tokenizers split text into manageable pieces. Byte-Pair Encoding (BPE) and WordPiece are common algorithms that build a vocabulary of subword units. Each token is mapped to an integer ID so it can be processed by the model. The vocabulary typically includes special symbols like `<pad>` for padding sequences and `<eos>` for marking the end of a sentence. Proper tokenization yields consistent sequence lengths and reduces out-of-vocabulary issues.
+
+## 4. Training Algorithms
+Training begins with massive text corpora that are shuffled and broken into fixed-length sequences. The transformer processes each batch while the optimizer updates weights via gradient descent. Strategies such as gradient accumulation, mixed-precision training and data parallelism enable scaling to billions of parameters. Many teams further align the model with Reinforcement Learning from Human Feedback (RLHF), which uses human preference scores and Proximal Policy Optimization to refine responses.
+
+## 5. Using Hosted APIs
 Most developers access LLMs through web APIs. When sending prompts, it’s important to manage context length, system instructions and rate limits. Providers like OpenAI return responses in JSON format with metadata. Error handling ensures robust applications.
 
 ### Example
@@ -48,13 +57,34 @@ print(response.choices[0].message.content)
 - Monitor token usage to avoid unexpected bills.
 - Evaluate model outputs for bias or inappropriate content.
 
-## 4. Evaluation and Fine-tuning
+## 6. Evaluation and Fine-tuning
 While base models provide impressive capabilities, performance often improves with fine-tuning on task-specific data. Evaluation metrics such as perplexity, BLEU or human preference scores help determine whether fine-tuning is necessary.
 
 ### Parameter-Efficient Methods
 Techniques like LoRA (Low-Rank Adaptation) and prompt tuning modify only a small subset of model parameters or the input embeddings, enabling efficient adaptation even on modest hardware.
 
-## 5. Ethical and Practical Concerns
+## 7. Ethical and Practical Concerns
 Large models inherit biases present in their training data. It is critical to monitor for unfair or harmful outputs. Data privacy must be considered when sending user content to hosted services. Finally, the energy consumption required to train these models raises environmental concerns. Organizations should weigh these factors when deciding on adoption.
+
+## 8. Hands-on Code Example
+The snippet below shows how a small transformer model can be fine-tuned using the `transformers` library from Hugging Face.
+```python
+from datasets import load_dataset
+from transformers import (AutoTokenizer, AutoModelForCausalLM,
+                          Trainer, TrainingArguments)
+
+tokenizer = AutoTokenizer.from_pretrained('gpt2')
+model = AutoModelForCausalLM.from_pretrained('gpt2')
+
+def tokenize(batch):
+    return tokenizer(batch['text'], truncation=True, padding='max_length')
+
+data = load_dataset('wikitext', 'wikitext-2-raw-v1')
+tokenized = data['train'].map(tokenize, batched=True)
+
+args = TrainingArguments('out', per_device_train_batch_size=2, num_train_epochs=1)
+trainer = Trainer(model=model, args=args, train_dataset=tokenized)
+trainer.train()
+```
 
 By the end of week two you will be able to describe the architecture of modern LLMs, interact with them via APIs and understand the trade-offs between proprietary and open-source solutions.

--- a/docs/03_rag_embedding.md
+++ b/docs/03_rag_embedding.md
@@ -7,7 +7,9 @@ Retrieval Augmented Generation (RAG) combines the reasoning abilities of languag
 - the RAG workflow
 - embedding models
 - vector databases
+- similarity search algorithms
 - building a RAG system
+- evaluation metrics
 - challenges and best practices
 - implementation exercise
 
@@ -21,6 +23,8 @@ By retrieving supporting evidence, RAG reduces hallucination and enables up-to-d
 ## 2. Embedding Models
 Sentence transformers (e.g., `all-MiniLM` or `bge-large`) convert text into high-dimensional vectors. These vectors capture semantic meaning, allowing similarity search. Fine-tuning on domain data improves retrieval quality.
 
+Other embedding approaches include dual-encoder models where questions and documents are encoded separately, and cross-encoders that jointly score a query-document pair. Dual-encoders scale well to large corpora while cross-encoders can provide higher accuracy when reranking the top retrieved results.
+
 ### Training Strategies
 - **Unsupervised**: Use contrastive learning on large corpora to build general-purpose embeddings.
 - **Supervised**: Train on question–answer pairs or labelled data for more accurate retrieval.
@@ -33,7 +37,20 @@ Specialized databases store millions of embeddings and provide efficient similar
 ### Indexing
 Vectors are often compressed or quantized for speed. Inverted file (IVF) indexes and HNSW graphs allow approximate nearest-neighbor search with controllable accuracy.
 
-## 4. Building a RAG System
+## 4. Similarity Search Algorithms
+Vector search relies on distance metrics such as cosine or Euclidean similarity.
+Large datasets use approximate nearest-neighbor (ANN) methods to keep latency
+low. Algorithms like HNSW build a navigable small-world graph, while IVF splits
+vectors into clusters for coarse-to-fine retrieval. Choosing the right index
+depends on trade-offs between speed, memory and recall.
+
+### Data Structures
+- **HNSW Graphs** organize vectors as layered graphs with short- and long-range
+  links to enable logarithmic search complexity.
+- **Inverted File Lists** partition vectors into buckets for efficient scanning
+  of a subset of the dataset.
+
+## 5. Building a RAG System
 1. Chunk documents into passages (e.g., 200–300 words).
 2. Embed each chunk and store it in a vector database along with metadata.
 3. When a query arrives, encode it and retrieve the top-k similar chunks.
@@ -51,12 +68,20 @@ question = "What is in the document?"
 matched_docs = store.similarity_search(question)
 ```
 
-## 5. Challenges and Best Practices
+## 6. Evaluation Metrics
+To gauge retrieval quality we measure recall—the proportion of relevant documents
+returned—as well as precision and overall latency. Evaluating the end-to-end RAG
+pipeline may involve human judgement of answer correctness or automatic metrics
+such as ROUGE for summarization tasks.
+
+## 7. Challenges and Best Practices
 - **Chunking Strategy**: Overlapping windows can preserve context but increase storage.
 - **Metadata**: Storing source links allows the generation step to cite references.
 - **Freshness**: Periodically re-embed new documents so the knowledge base stays current.
 
-## 6. Implementation Exercise
+## 8. Implementation Exercise
 Create a simple question-answering system that reads a set of articles, embeds them into a FAISS index and uses an LLM to respond to user questions with retrieved passages. Evaluate how retrieval quality changes when using different embedding models or index parameters.
 
 By completing week three you will know how to integrate vector search with language models to build applications that provide grounded, accurate answers.
+
+Further reading includes papers on Dense Passage Retrieval and RAG-based open-domain question answering. Experiment with different embedding models and index parameters to understand the trade-offs between accuracy and latency.

--- a/docs/04_prompt_engineering.md
+++ b/docs/04_prompt_engineering.md
@@ -7,8 +7,10 @@ Week four explores how to craft prompts that reliably steer language models towa
 - prompt design principles
 - zero-shot, few-shot and chain-of-thought
 - using system prompts
+- prompt templates and data structures
 - advanced formatting
 - prompt iteration and evaluation
+- automated optimization
 - practical exercise
 
 ## 1. Prompt Design Principles
@@ -34,7 +36,19 @@ System prompts establish the role or persona of the assistant, such as "You are 
 ### Controlling Style
 We can mimic styles ranging from academic explanations to casual conversation. Including explicit style cues helps tailor the voice to the target audience.
 
-## 4. Advanced Formatting
+## 4. Prompt Templates and Data Structures
+Complex applications store prompts as templates with placeholders. A template may
+be expressed as a Python string with `{variable}` tokens or as a structured
+object containing fields for system, user and tool messages. Managing prompts as
+data enables version control and automated testing.
+
+### Example Template
+```python
+template = """You are a math tutor.\nQuestion: {question}\nAnswer:"""
+filled = template.format(question="What is 2+2?")
+```
+
+## 5. Advanced Formatting
 When output needs to be machine-readable, we can instruct the model to respond in JSON or Markdown. Using placeholders and bullet lists reduces variation in the output structure.
 
 ### Example Prompt
@@ -44,10 +58,31 @@ Answer the question using three bullet points.
 Question: How can I reduce latency in a web app?
 ```
 
-## 5. Prompt Iteration and Evaluation
+### Temperature and Top-p
+The randomness of model output is controlled with the `temperature` and
+`top_p` parameters. Lower temperature produces more deterministic responses,
+while a higher value encourages creative or varied text. Nucleus sampling
+(`top_p`) limits generation to the most probable tokens whose cumulative
+probability is below a threshold, often producing coherent yet diverse answers.
+
+## 6. Prompt Iteration and Evaluation
 Developing a good prompt is an iterative process. Start with a clear baseline, test the output on multiple examples and refine. Automated evaluation frameworks such as OpenAI’s prompt engineering tools or the `langchain` evaluator can assist with this process.
 
-## 6. Practical Exercise
+Evaluation often measures metrics like exact match on benchmark tasks or user satisfaction collected through ratings. Tracking how prompts perform across multiple criteria helps identify trade-offs between brevity, accuracy and style. Version control of prompts enables A/B testing and regression checks.
+
+## 7. Automated Optimization
+Tools such as prompt matrices and evolutionary algorithms can automatically test
+variations of a base prompt. By measuring accuracy or user satisfaction we can
+select the best-performing template. This approach scales when manual iteration
+becomes impractical.
+
+One common strategy is to randomly sample variations of wording or ordering within a prompt and score them with a reference answer. Gradient-free optimization methods such as Bayesian search can then converge on high-performing prompts with fewer trials.
+
+## 8. Practical Exercise
 Design prompts for a summarization tool and a data extraction pipeline. Experiment with different temperature settings and evaluate how formatting instructions affect the consistency of the model’s responses.
 
 By the end of week four you will be able to write prompts that consistently guide LLMs to produce high-quality, safe and formatted output for a variety of tasks.
+
+Continuous improvement is key. Save successful prompts in a library and track
+their performance on real user queries. Over time these prompt libraries become
+valuable assets that accelerate development of new LLM applications.

--- a/docs/05_ai_applications.md
+++ b/docs/05_ai_applications.md
@@ -5,8 +5,10 @@ Week five focuses on integrating language models into real-world applications. W
 ## Outline
 
 - application patterns
+- system architecture and data pipelines
 - evaluation and feedback
 - safety considerations
+- monitoring and logging
 - implementation exercise
 
 ## 1. Application Patterns
@@ -21,16 +23,58 @@ Automatic summarization condenses large documents into key points. Whether abstr
 ### Knowledge Extraction
 Businesses use LLMs to identify entities and relationships within text. By combining extraction prompts with downstream databases, we can build structured knowledge bases from unstructured sources.
 
-## 2. Evaluation and Feedback
+## 2. System Architecture and Data Pipelines
+LLM applications often follow a microservice design. A front-end interface sends
+requests to a back-end service that orchestrates calls to the language model and
+any retrieval databases. Message queues or streaming systems pass conversation
+history and user feedback to analytics components. Choosing whether to call a
+hosted API or deploy a model locally depends on latency, cost and privacy.
+
+### Data Schemas
+Storing conversations typically involves a table of messages with columns for
+timestamp, user ID and text. Vector databases may store embeddings alongside the
+raw documents for retrieval.
+
+## 3. Evaluation and Feedback
 Deploying an LLM-powered app is an iterative process. We should monitor metrics such as response quality, latency and user satisfaction. A/B testing different prompt templates or model parameters helps determine what works best. Collecting explicit user feedback allows continuous improvement.
+
+Quantitative evaluation includes measuring perplexity or other automated metrics, while qualitative studies gather insights from domain experts. Maintaining test datasets with expected answers ensures that new model versions do not regress on established functionality.
 
 ### Human-in-the-Loop
 In sensitive domains, humans review model outputs before final delivery. This ensures accuracy and prevents harmful content from reaching end users.
 
-## 3. Safety Considerations
+## 4. Safety Considerations
 LLMs can hallucinate or produce biased text. Implement guardrails such as content filters, rate limiting and logging. Privacy is also vital—avoid sending sensitive user data to external services unless it has been properly anonymized and consent has been obtained.
 
-## 4. Implementation Exercise
+## 5. Monitoring and Logging
+Production systems should log every request and response for troubleshooting and
+analysis. Metrics such as response time, token usage and user satisfaction scores
+help diagnose regressions. Dashboards enable operators to spot spikes in latency
+or abnormal output.
+
+## 6. Implementation Exercise
 Design a simple application that integrates a chat interface with an LLM API. Track metrics such as user retention and feedback ratings. Experiment with prompt variants to improve helpfulness while maintaining safe responses.
 
+### Example Code
+```python
+import openai
+
+chat_history = []
+
+def chat(question):
+    chat_history.append({"role": "user", "content": question})
+    resp = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chat_history)
+    answer = resp.choices[0].message.content
+    chat_history.append({"role": "assistant", "content": answer})
+    return answer
+```
+
 After week five you will know how to plan and build LLM applications with a focus on evaluation, safety and user-centered design.
+
+Thorough monitoring and iterative prompt design will ensure your applications remain reliable as models and requirements evolve.
+
+## 7. Additional Resources
+- Papers on LLM application design, such as OpenAI's documentation and industry
+  case studies.
+- Frameworks like LangChain and LlamaIndex provide utilities for rapid
+  prototyping and evaluation.

--- a/docs/06_ai_agent_langchain.md
+++ b/docs/06_ai_agent_langchain.md
@@ -6,7 +6,9 @@ In week six we explore LangChain, a Python framework for building agents that ch
 
 - building chains
 - tools and plugins
+- agent memory and state
 - multi-step agents
+- evaluation techniques
 - example project
 - further exploration
 
@@ -15,6 +17,7 @@ A chain is a sequence of prompts, model invocations and actions. LangChain makes
 
 ### Memory Management
 Conversation memory objects store user messages and model responses. This allows an agent to maintain context over extended dialogues. Different memory types support summarization or token-limited histories.
+Persistent memory classes write interactions to disk or a database so agents can resume conversations even after a restart. Summarizing memory compresses long transcripts into embeddings or key sentences to fit within model context windows.
 
 ## 2. Tools and Plugins
 LangChain integrates with many tools such as web search, code execution sandboxes and vector stores. Tools are invoked by the agent when it determines additional data is needed to answer a question.
@@ -22,21 +25,50 @@ LangChain integrates with many tools such as web search, code execution sandboxe
 ### Custom Tools
 Developers can define their own tools by writing a function and registering it with the agent. Tools may access internal APIs, databases or external services.
 
-## 3. Multi-step Agents
+## 3. Agent Memory and State
+Agents maintain state across turns using different memory classes. Simple buffer
+memory stores the full conversation while summary memory compresses old
+exchanges to keep prompts short. Key-value memory can hold structured data such
+as the user’s name or preferences for use in later steps.
+
+## 4. Multi-step Agents
 Complex tasks often require retrieval, reasoning and action in sequence. For example an agent might search documentation, parse the results and then compose a concise answer. LangChain provides higher-level agent classes that handle decision making and tool selection.
 
 ### Debugging and Tracing
 LangChain includes verbose logging and tracing utilities. These help inspect the reasoning process of the agent and diagnose unexpected behavior.
 
-## 4. Example Project
+## 5. Example Project
 Build a question answering assistant that looks up information in a vector store before replying. The chain uses the following steps:
 1. Receive the user question.
 2. Retrieve relevant documents from a vector database.
 3. Feed the documents and question to a language model.
 4. Return the model’s summarized answer along with references.
 
-## 5. Further Exploration
+### Sample Code
+```python
+from langchain.chains import RetrievalQA
+from langchain.llms import OpenAI
+from langchain.vectorstores import FAISS
+
+vector_store = FAISS.load_local('docs_index')
+llm = OpenAI(model_name='gpt-3.5-turbo')
+qa = RetrievalQA(llm=llm, retriever=vector_store.as_retriever())
+response = qa.run('How do I install the package?')
+print(response)
+```
+
+## 6. Evaluation Techniques
+Evaluate agents by logging intermediate steps and checking whether the chosen
+tools lead to correct answers. LangChain provides tracing utilities that export
+JSON traces for later analysis. You can also score final answers against a test
+set or human ratings.
+
+## 7. Further Exploration
 - Experiment with different chain structures such as sequential chains or parallel tool calls.
 - Use the LangChain evaluation module to benchmark your agent’s performance.
 
 By the end of week six you will be prepared to design complex LLM agents that use external tools and memory to solve real problems.
+
+The LangChain documentation includes many advanced patterns such as ReAct-style
+reasoning and planner-executor designs. Experiment with these templates to build
+agents that can perform multi-step research or workflow automation.

--- a/docs/07_llm_solutions.md
+++ b/docs/07_llm_solutions.md
@@ -8,19 +8,50 @@ The final week surveys complete solutions built with language models across diff
 - summarization and question answering
 - domain automation
 - deployment considerations
+- evaluation and analytics
 - capstone project
+
+Throughout this week we connect the theory from earlier modules to real-world
+deployments. Each domain presents unique challenges around data privacy, latency
+and user experience, but common architectural patterns emerge.
 
 ## 1. Conversational Systems
 Chatbots and virtual assistants automate customer service and technical support. Effective systems combine retrieval (for factual accuracy) with dialogue management. Tools such as sentiment detection help tailor responses to user emotions.
 
+Large deployments often integrate with CRM platforms to fetch account details and update tickets automatically. Multi-turn dialogue management ensures context is preserved across sessions.
+
 ## 2. Summarization and Question Answering
 Organizations use LLMs to condense lengthy reports or answer natural language queries over internal documents. Combining RAG pipelines with prompt engineering yields concise, trustworthy results.
+
+Techniques like map-reduce summarization process long documents in chunks and then compose a final answer. Cross-encoders can rerank retrieved passages for better accuracy.
 
 ## 3. Domain Automation
 In finance, language models analyze market reports and generate portfolio summaries. Healthcare applications include patient triage chatbots and medical coding assistance. In education, tutors generate practice questions and personalized feedback.
 
+Automation pipelines typically involve extraction prompts followed by downstream data processing. Integrating LLMs with existing business workflows requires careful handling of edge cases and fallback procedures.
+
 ## 4. Deployment Considerations
 To run these solutions at scale we need secure infrastructure, monitoring and failover plans. Choosing between cloud-hosted APIs or self-hosted models depends on latency, cost and privacy requirements. Logging and analytics help track performance over time.
+Container orchestration platforms such as Kubernetes simplify scaling and enable rolling updates. When deploying sensitive models on-premises, encryption and role-based access control are essential to protect proprietary data.
 
-## 5. Capstone Project
+## 5. Evaluation and Analytics
+Production systems must monitor both technical metrics and user satisfaction. Key metrics include response latency, accuracy on benchmark questions and conversation length. Analytics platforms such as Elastic or DataDog can collect logs for troubleshooting and trend analysis.
+
+Regular evaluation days allow teams to review logs and fine-tune prompts or retrievers. Over time, this data builds a feedback loop that guides future model updates and training.
+
+## 6. Capstone Project
 Students are encouraged to design a small end-to-end application incorporating retrieval, prompt engineering and an LLM agent. Presentations at the end of the course showcase the creativity and technical depth achieved during the seven weeks.
+
+## 7. Case Studies
+- **E-commerce Chatbot**: uses product embeddings to recommend items and answer
+  queries about inventory.
+- **Legal Document Summarizer**: assists lawyers by extracting key clauses and
+  summarizing long contracts.
+- **Healthcare Assistant**: triages symptoms and schedules appointments while
+  adhering to regulatory requirements.
+- **Educational Tutor**: generates practice problems and adaptive feedback for
+  students preparing for exams.
+
+By studying these complete solutions you will understand how the concepts from earlier weeks combine to create robust, real-world products powered by language models.
+
+Continued experimentation will reveal new possibilities as LLM technology evolves, enabling innovative services across every sector.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 # Prompt Engineering Guide
-This guide provides information for Prompt Engineering and working with LLMs.
+This guide provides information for Prompt Engineering and working with LLMs. Each topic delves into theory, data structures and practical algorithms so you can build end‑to‑end solutions.
 
 Each topic page includes a **Contents Outline** section at the beginning so you
 can quickly navigate the material and locate key subtopics.


### PR DESCRIPTION
## Summary
- enrich topic modules with theory, algorithms and code
- update landing page intro
- log session activity in release notes

## Testing
- `pip install mkdocs`
- `pip install mkdocs-material`
- `python -m mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_686a2bc4b3a08323bc35015033cc6df8