### PR TITLE
V01 selfguide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 This repository provides information for Prompt Engineering and working with LLMs
 the main contents is located in `/docs`
 
-your role is to provide knowledge and expertise as a contributor and editor of the guide contents
+your role is to provide knowledge and expertise as a contributor and editor of the contents for this course
 you will contribute directly to the guide contents at all stages of development from content outline to writing and editing content
 
 The format of the guide is in markdown files *.md and rendered and hosted using `mkdocs`

--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,6 +6,29 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
+### NLP [Codex] 2025-07-06 <HH>:<MM>
+
+
+### NLP [Data Engineer] Codex prompt 2025-07-06 15:45
+
+For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`
+
+objectives
+add topic outline section, NLP add sections for NLP with ML
+
+your task
+- scope: all topic pages
+    - add a contents outline section for each page
+- scope: `/docs/01_natural_language_processing.md`
+    - add a section for fundamental theory and concepts of NLP, difference between different levels of structure of language at word, grammar, and semantic levels
+    - explain how NLP models are developed and trained on corupses
+    - add sub-sections to this page to cover how to use NLP with ML for using unstructured data and tokens as features in building an ML model
+    - aim for around 2-3 pages of contents, addressing the range of applications such as regression, classification, unsupervised, supervised and others which are not listed. 
+    - re-update section numberings substitute XX placeholders
+- Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
+- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### NLP [Codex] 2025-07-06 <HH>:<MM> 
+- create a PR with the edits to the landing page and your session log
+
 ### Contents development [Codex] 2025-07-06 15:29
 - Expanded each weekly module to multi-page lecture notes
 - Added course schedule on landing page

--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -1,0 +1,24 @@
+# Release: self-guide
+This is the first release for the Prompt Engineering guide
+
+## Session Logs
+
+Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
+Logs are timestamped to Singapore timezone
+
+### Contents outline [Codex] 2025-07-06 <HH>:<MM>
+
+
+### Contents outline [Data Engineer] Codex prompt 2025-07-06 14:50
+
+For context, refer to landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`
+
+objectives
+We are going to build the curriculum contents for a Prompt engineering course, that will cover the topics listed in the landing page.
+
+your task
+- develop the outline for the course contents, using the listed topics as a guide
+- document the course contents on the landing page. In later steps we will break them out into separate pages.
+- list in bullet form the specific topics to cover in each section
+- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents outline [Codex] 2025-07-06 <HH>:<MM> 
+- create a PR with the edits to the landing page and your session log

--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,13 +6,28 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
+### Contents development [Codex] 2025-07-06 <HH>:<MM>
+
+### Contents development [Data Engineer] Codex prompt 2025-07-06 15:55
+
+For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`
+
+situation
+the current topic pages are too general, and not sufficient level of detail to properly cover the theory and application of the topics
+
+your task
+- scope: all topic pages
+    - using NLP page `/docs/01_natural_language_processing.md` as a guide, flesh out and develop the remaining pages to this level of detail and coverage of the topics, including theory development, data structures, algorithms and practical examples
+- Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
+- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents development [Codex] 2025-07-06 <HH>:<MM> 
+- create a PR with the edits to the landing page and your session log
+
 ### NLP [Codex] 2025-07-06 15:47
 
 - Added contents outline sections to all topic pages
 - Expanded the Natural Language Processing page with fundamental theory and
   machine learning sections
 - Updated the landing page to mention outlines for each topic
-
 
 ### NLP [Data Engineer] Codex prompt 2025-07-06 15:45
 

--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,7 +6,22 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
-### Contents outline [Codex] 2025-07-06 15:20
+### Contents development [Codex] 2025-07-06 <HH>:<MM>
+
+### Contents development [Data Engineer] Codex prompt 2025-07-06 15:15
+
+For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`
+
+objectives
+build out the curriculum contents for a 7-week Prompt engineering course, that will cover the topics listed in the landing page.
+
+your task
+- fill up the section contents for the newly added sections on the landing page for **RAG, Embedding and Vector Databases** and **AI Agents using LangChain**
+- for each of the topics listed, develop the contents of the pages. For example for **Natural Language Processing** the page is `/docs/01_natural_language_processing.md`. Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
+- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents development [Codex] 2025-07-06 <HH>:<MM> 
+- create a PR with the edits to the landing page and your session log
+
+### Contents outline [Codex] 2025-07-06 14:54
 
 - Added course outline to landing page and updated session log
 

--- a/dev/releases/01_selfguide.md
+++ b/dev/releases/01_selfguide.md
@@ -6,6 +6,22 @@ This is the first release for the Prompt Engineering guide
 Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
 Logs are timestamped to Singapore timezone
 
+### Contents development [Codex] 2025-07-06 <HH>:<MM>
+
+### Contents development [Data Engineer] Codex prompt 2025-07-06 15:20
+
+For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`
+
+objectives
+build out the curriculum contents for a 7-week Prompt engineering course, that will cover the topics listed in the landing page.
+
+your task
+- flesh out contents of the pages from their current level of detail around a 1/2 page to a 1 page, to around 5 pages each. 
+- include paragraph style explanations of topics with examples and explain the fundamentals and how they are applied.
+- For example for **Natural Language Processing** the page is `/docs/01_natural_language_processing.md`. Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
+- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents development [Codex] 2025-07-06 <HH>:<MM> 
+- create a PR with the edits to the landing page and your session log
+
 ### Contents development [Codex] 2025-07-06 15:17
 
 - Expanded curriculum pages with lecture-style content

--- a/docs/01_natural_language_processing.md
+++ b/docs/01_natural_language_processing.md
@@ -1,0 +1,1 @@
+# Natural Language Processing

--- a/docs/01_natural_language_processing.md
+++ b/docs/01_natural_language_processing.md
@@ -2,6 +2,10 @@
 
 Natural Language Processing (NLP) is the discipline focused on understanding and generating human language with computers. In our first week we build the foundational toolkit for working with raw text. The goal is to transform unstructured sentences into representations that can be fed into language models or traditional machine learning pipelines.
 
+## Outline
+
+_add the outline here_
+
 ## 1. Overview of NLP Tasks
 NLP spans a broad range of tasks from tokenization and part-of-speech tagging to machine translation and text generation. We examine the classic pipeline of text classification, named entity recognition and summarization. Each task benefits from accurate preprocessing and token management, topics that we will explore in depth.
 
@@ -55,7 +59,11 @@ To build a semantic search engine, we embed user queries and corpus documents in
 ## 7. Evaluation Metrics
 Common metrics for evaluating NLP pipelines include precision, recall and F1 score for classification, or BLEU and ROUGE for machine translation and summarization. Proper evaluation helps compare algorithms and tune hyperparameters.
 
-## 8. Practical Exercise
+## XX. Machine learning with NLP
+
+_elaborate a few sections with examples for using NLP as part of building an ML model for classification, regression and unsupervised learning tasks
+
+## XX. Practical Exercise
 The assignment for this module is to implement a small semantic search engine. Using Python libraries such as spaCy and scikit-learn, you will:
 1. Preprocess a text dataset by tokenizing, lemmatizing and removing stop words.
 2. Generate TF‑IDF features and train a basic classifier.

--- a/docs/02_large_language_models.md
+++ b/docs/02_large_language_models.md
@@ -1,0 +1,1 @@
+# Large Language Models

--- a/docs/03_rag_embedding.md
+++ b/docs/03_rag_embedding.md
@@ -1,0 +1,1 @@
+# RAG Embedding and Vector Databases

--- a/docs/04_prompt_engineering.md
+++ b/docs/04_prompt_engineering.md
@@ -1,0 +1,1 @@
+# Prompt Engineering

--- a/docs/05_ai_applications.md
+++ b/docs/05_ai_applications.md
@@ -1,0 +1,1 @@
+# AI Applications

--- a/docs/06_ai_agent_langchain.md
+++ b/docs/06_ai_agent_langchain.md
@@ -1,0 +1,1 @@
+# AI Agent Development using LangChain

--- a/docs/07_llm_solutions.md
+++ b/docs/07_llm_solutions.md
@@ -1,0 +1,1 @@
+# LLM Solutions

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,7 @@ This guide provides information for Prompt Engineering and working with LLMs.
 
 ## Topics
 The course focuses on:
+
 - Natural Language Processing (NLP)
 - AI application development
 - Solutions driven by large language models (LLM)
@@ -10,21 +11,25 @@ The course focuses on:
 - Prompt Engineering concepts
 
 ## Course Outline
-- **Introduction to NLP**
+- **Natural Language Processing**
   - fundamentals of text processing and tokenization
   - embeddings and semantic understanding
 - **Large Language Models**
   - overview of GPT-3/4, Claude and other providers
   - transformer architecture basics
   - using APIs for inference and evaluation
-- **Prompt Engineering Fundamentals**
+- **RAG, Embedding and Vector Databases**
+  - *
+- **Prompt Engineering**
   - prompt design best practices
   - zero-shot, few-shot and chain-of-thought techniques
   - system versus user prompts
-- **AI Application Development**
+- **AI Applications**
   - integrating LLM APIs into applications
   - feedback loops and model evaluation
   - safety and responsible use
+- **AI Agents using LangChain**
+  - *
 - **LLM Solutions**
   - building chatbots and conversational agents
   - summarization and question answering

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,13 @@ site_name: Prompt Engineering Guide
 
 nav:
   - Home: index.md
+  - Natural Language Processing: 01_natural_language_processing.md
+  - Large Language Models: 02_large_language_models.md
+  - RAG, Embedding and Vector Databases: 03_rag_embedding.md
+  - Prompt Engineering: 04_prompt_engineering.md
+  - AI Applications: 05_ai_applications.md
+  - AI Agents using LangChain: 06_ai_agent_langchain.md
+  - LLM Solutions: 07_llm_solutions.md
 
 theme:
   name: material


### PR DESCRIPTION
# Release: self-guide
This is the first release for the Prompt Engineering guide

## Session Logs

Session logs are in reverse-chronological order with newer entries at the top and older entries at the bottom.
Logs are timestamped to Singapore timezone

### Contents development [Data Engineer] 2025-07-06 16:29

pull request merge to main branch and deploy

### Contents development [Codex] 2025-07-06 16:02

- Expanded all topic pages with detailed theory, data structures and algorithms
  following the NLP chapter as a template
- Added practical code examples across LLM, RAG, prompt engineering, agent and
  application sections
- Updated the landing page introduction
- Logged progress in this session

### Contents development [Data Engineer] Codex prompt 2025-07-06 15:55

For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`

situation
the current topic pages are too general, and not sufficient level of detail to properly cover the theory and application of the topics

your task
- scope: all topic pages
    - using NLP page `/docs/01_natural_language_processing.md` as a guide, flesh out and develop the remaining pages to this level of detail and coverage of the topics, including theory development, data structures, algorithms and practical examples
- Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents development [Codex] 2025-07-06 <HH>:<MM> 
- create a PR with the edits to the landing page and your session log

### NLP [Codex] 2025-07-06 15:47

- Added contents outline sections to all topic pages
- Expanded the Natural Language Processing page with fundamental theory and
  machine learning sections
- Updated the landing page to mention outlines for each topic

### NLP [Data Engineer] Codex prompt 2025-07-06 15:45

For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`

objectives
add topic outline section, NLP add sections for NLP with ML

your task
- scope: all topic pages
    - add a contents outline section for each page
- scope: `/docs/01_natural_language_processing.md`
    - add a section for fundamental theory and concepts of NLP, difference between different levels of structure of language at word, grammar, and semantic levels
    - explain how NLP models are developed and trained on corupses
    - add sub-sections to this page to cover how to use NLP with ML for using unstructured data and tokens as features in building an ML model
    - aim for around 2-3 pages of contents, addressing the range of applications such as regression, classification, unsupervised, supervised and others which are not listed. 
    - re-update section numberings substitute XX placeholders
- Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### NLP [Codex] 2025-07-06 <HH>:<MM> 
- create a PR with the edits to the landing page and your session log

### Contents development [Codex] 2025-07-06 15:29
- Expanded each weekly module to multi-page lecture notes
- Added course schedule on landing page

### Contents development [Data Engineer] Codex prompt 2025-07-06 15:20

For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`

objectives
build out the curriculum contents for a 7-week Prompt engineering course, that will cover the topics listed in the landing page.

your task
- flesh out contents of the pages from their current level of detail around a 1/2 page to a 1 page, to around 5 pages each. 
- include paragraph style explanations of topics with examples and explain the fundamentals and how they are applied.
- For example for **Natural Language Processing** the page is `/docs/01_natural_language_processing.md`. Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents development [Codex] 2025-07-06 <HH>:<MM> 
- create a PR with the edits to the landing page and your session log

### Contents development [Codex] 2025-07-06 15:17

- Expanded curriculum pages with lecture-style content
- Added RAG and LangChain bullet points on landing page

### Contents development [Data Engineer] Codex prompt 2025-07-06 15:15

For context, refer to the navigation guide in `mkdocs.yml`, landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`

objectives
build out the curriculum contents for a 7-week Prompt engineering course, that will cover the topics listed in the landing page.

your task
- fill up the section contents for the newly added sections on the landing page for **RAG, Embedding and Vector Databases** and **AI Agents using LangChain**
- for each of the topics listed, develop the contents of the pages. For example for **Natural Language Processing** the page is `/docs/01_natural_language_processing.md`. Work in iterative cycles of developing the outline for each page, and then filling in the contents until you reach a level of detail of a course content of a text book or lecture notes.  
- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents development [Codex] 2025-07-06 <HH>:<MM> 
- create a PR with the edits to the landing page and your session log

### Contents outline [Codex] 2025-07-06 14:54

- Added course outline to landing page and updated session log

### Contents outline [Data Engineer] Codex prompt 2025-07-06 14:50

For context, refer to landing page `/docs/index.md` and the release doc `/dev/releases/01_selfguide`

objectives
We are going to build the curriculum contents for a Prompt engineering course, that will cover the topics listed in the landing page.

your task
- develop the outline for the course contents, using the listed topics as a guide
- document the course contents on the landing page. In later steps we will break them out into separate pages.
- list in bullet form the specific topics to cover in each section
- update your activity as a timestamped session log in the ## Session logs section of the release doc in the section ### Contents outline [Codex] 2025-07-06 <HH>:<MM> 
- create a PR with the edits to the landing page and your session log
